### PR TITLE
Fjernet "Logout" knapp fra ProfileSettingsScreen. Dette ble gjort av …

### DIFF
--- a/app/src/main/java/com/example/moveapp/ui/screens/profile/ProfileSettingsScreen.kt
+++ b/app/src/main/java/com/example/moveapp/ui/screens/profile/ProfileSettingsScreen.kt
@@ -217,19 +217,6 @@ fun ProfileSettingsScreen(navController: NavController) {
                 ) {
                 Text(text = stringResource(R.string.send_password_reset_email))
             }
-
-
-            // Logout Button
-            Button(onClick = {
-                coroutineScope.launch {
-                    val user = logoutUser(context)
-                    if (user != null) {
-                        navController.navigate(AppScreens.LOGIN.name)
-                    }
-                }
-            }) {
-                Text(text = stringResource(R.string.logout))
-            }
         }
     }
 }


### PR DESCRIPTION
…2 grunner. 1. Funksjonaliteten er flyttet til profile sub-menyen. 2. Halve knappen ble dekket av BottomNavBar og var vanskelig å trykke på.